### PR TITLE
add port forward for viztracer-vscode

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -31,9 +31,13 @@ function runVizViewer(pythonPath, reportPath, port)
             vscode.window.showErrorMessage("Please install vizviewer to view the report");
         } else if (m = regex.exec(message)) {
             let url = m[1];
-            openInWebview(url, path.basename(reportPath), () => {
-                process.kill();
-            });
+            vscode.env.asExternalUri(vscode.Uri.parse(url)).then(
+                externalUri => {
+                    openInWebview(externalUri, path.basename(reportPath), () => {
+                        process.kill();
+                    });
+                }
+            )
         } else if (message.includes('Traceback')) {
             vscode.window.showErrorMessage("Error occurred when viewing the report");
         } else if (message.includes('already in use')) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -33,7 +33,7 @@ function runVizViewer(pythonPath, reportPath, port)
             let url = m[1];
             vscode.env.asExternalUri(vscode.Uri.parse(url)).then(
                 externalUri => {
-                    openInWebview(externalUri, path.basename(reportPath), () => {
+                    openInWebview(externalUri.toString(), path.basename(reportPath), () => {
                         process.kill();
                     });
                 }


### PR DESCRIPTION
Add port forward for viztracer-vscode.

The current way to forward a port may have some issue. If a port is used by the client. The forward will not work. 